### PR TITLE
CRAN Check Failing for Upcoming broom 0.7.0 Release

### DIFF
--- a/tests/testthat/test-glance.timedist.R
+++ b/tests/testthat/test-glance.timedist.R
@@ -10,7 +10,7 @@ test_that("Ensure the glance method is returning expected values", {
       sigma = 0.0595516186299733, isConv = TRUE, finTol = 1.49011611938477e-08,
       logLik = 21.3157601682213, AIC = -34.6315203364427,
       BIC = -32.0752910179816, deviance = 0.0390103480959477, df.residual = 11L,
-      RSS = 0.968195658520631
+      nobs = 14, RSS = 0.968195658520631
     ),
     class = "data.frame", row.names = c(NA, -1L)
   )


### PR DESCRIPTION
Hey there! 

The upcoming release of broom (0.7.0) introduced a new error in your unit tests. The glance method you test now returns an `nobs` column. This PR will fix the failing test!

We hope to submit the new version (on the `0.7.0-rc` [branch](https://github.com/tidymodels/broom/tree/0.7.0-rc)) in the coming weeks. Please let us know if you'd appreciate any other support from us in getting a new release up in the meantime!